### PR TITLE
FEATURE: Allow to store `sitekey` and `secret` in Settings.yaml

### DIFF
--- a/Classes/Gerdemann/ReCAPTCHA/FormElements/ReCAPTCHAFormElement.php
+++ b/Classes/Gerdemann/ReCAPTCHA/FormElements/ReCAPTCHAFormElement.php
@@ -1,0 +1,22 @@
+<?php
+namespace Gerdemann\ReCAPTCHA\FormElements;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Form\Core\Model\AbstractFormElement;
+
+class ReCAPTCHAFormElement extends AbstractFormElement
+{
+    /**
+     * @var string
+     * @Flow\InjectConfiguration(package="Gerdemann.ReCAPTCHA", path="sitekey")
+     */
+    protected $sitekey;
+
+    /**
+     * @return string|null the site key from the settings
+     */
+    public function getSiteKey()
+    {
+        return $this->sitekey;
+    }
+}

--- a/Classes/Gerdemann/ReCAPTCHA/Validation/ReCAPTCHAValidator.php
+++ b/Classes/Gerdemann/ReCAPTCHA/Validation/ReCAPTCHAValidator.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gerdemann\ReCAPTCHA\Validation;
 
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Client\Browser;
 use Neos\Flow\Http\Client\CurlEngine;
 use Neos\Flow\Validation\Validator\AbstractValidator;
@@ -11,10 +12,16 @@ use Neos\Flow\Validation\Validator\AbstractValidator;
 class ReCAPTCHAValidator extends AbstractValidator
 {
     /**
+     * @var string
+     * @Flow\InjectConfiguration(package="Gerdemann.ReCAPTCHA", path="secret")
+     */
+    protected $secret;
+    
+    /**
      * @var array
      */
     protected $supportedOptions = array(
-        'secret' => array('', ' The shared key between your site and reCAPTCHA', 'string', true)
+        'secret' => array('', ' The shared key between your site and reCAPTCHA', 'string', false)
     );
 
     /**
@@ -27,7 +34,7 @@ class ReCAPTCHAValidator extends AbstractValidator
         $browser = new Browser();
         $browser->setRequestEngine(new CurlEngine());
         $arguments = array(
-            'secret' => $this->getOptions()['secret'],
+            'secret' => $this->getOptions()['secret'] ? $this->getOptions()['secret'] : $this->secret,
             'response' => $value
         );
         $response = $browser->request('https://www.google.com/recaptcha/api/siteverify', 'POST', $arguments);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -4,6 +4,7 @@ Neos:
       default:
         formElementTypes:
           'Gerdemann.ReCAPTCHA:ReCAPTCHA':
+            implementationClassName: Gerdemann\ReCAPTCHA\FormElements\ReCAPTCHAFormElement
             superTypes:
               'Neos.Form:FormElement': true
             renderingOptions:
@@ -15,3 +16,8 @@ Neos:
     fusion:
       autoInclude:
         Gerdemann.ReCAPTCHA: true
+
+Gerdemann:
+  ReCAPTCHA:
+    sitekey: ~
+    secret: ~

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ How-To:
           secret: 'ENTER_HERE_YOUR_SHARED_SECRET
   ```
 
+Settings:
+-----------
+
+You can predefine default values for `secret` and `sitekey` in
+`Settings.yaml`. If no specific values are given in the form the
+captcha-element will fallback to those values.
+
+  ```
+ Gerdemann:
+   ReCAPTCHA:
+     sitekey: ~
+     secret: ~
+  ```
+
+
 Hint:
 -------
 

--- a/Resources/Private/Form/ReCAPTCHA.html
+++ b/Resources/Private/Form/ReCAPTCHA.html
@@ -1,5 +1,5 @@
 <div class="g-recaptcha"
-     data-sitekey="{element.properties.sitekey}"
+     data-sitekey="{f:if(condition: element.properties.sitekey, then: element.properties.sitekey, else: element.sitekey)}"
      data-callback="onReCAPTCHASubmit"
      data-size="invisible">
 </div>


### PR DESCRIPTION
You can predefine the secret and sitekey in Settings.yaml. If no specific values are given in the form
the captcha-element will fallback to those values.