### PR TITLE
BUGFIX: Require neos/neos, not typo3/neos

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Neos plugin for Google reCAPTCHA",
     "license": "MIT",
     "require": {
-        "typo3/neos": "^3.0 || ^4.0"
+        "neos/neos": "^3.0 || ^4.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This makes sure the prototype changes will be picked up reliably.

Otherwise loading order issues may lead to Neos removing the
JS inclusion again.