### PR TITLE
Copy submit element to preserve __currentPage value

### DIFF
--- a/Resources/Public/JavaScript/ReCAPTCHA.js
+++ b/Resources/Public/JavaScript/ReCAPTCHA.js
@@ -43,7 +43,7 @@ function onReCAPTCHASubmit() {
     var currentPage = form.createElement('input');
     currentPage.type = 'hidden';
     currentPage.name = submitElement.name;
-    currentPage.value = submitElement.value
+    currentPage.value = submitElement.value;
     
     form.submit();
 }

--- a/Resources/Public/JavaScript/ReCAPTCHA.js
+++ b/Resources/Public/JavaScript/ReCAPTCHA.js
@@ -39,5 +39,11 @@ function onReCAPTCHASubmit() {
     while (form.nodeName != "FORM" && form.parentNode) {
         form = form.parentNode;
     }
+    
+    var currentPage = form.createElement('input');
+    currentPage.type = 'hidden';
+    currentPage.name = submitElement.name;
+    currentPage.value = submitElement.value
+    
     form.submit();
 }

--- a/Resources/Public/JavaScript/ReCAPTCHA.js
+++ b/Resources/Public/JavaScript/ReCAPTCHA.js
@@ -40,10 +40,11 @@ function onReCAPTCHASubmit() {
         form = form.parentNode;
     }
     
-    var currentPage = form.createElement('input');
+    var currentPage = document.createElement('input');
     currentPage.type = 'hidden';
     currentPage.name = submitElement.name;
     currentPage.value = submitElement.value;
+    form.appendChild(currentPage);
     
     form.submit();
 }


### PR DESCRIPTION
As mentioned in #5, the validation is not triggered server side, because of missing `__currentPage ` parameter. The `form.submit();` doesn't send the value of the button.

This change copies the name and value of the button into a hidden input field to preserve the name/value and to get it sent through the request.