### PR TITLE
Fix configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ How-To:
     properties:
       sitekey: 'ENTER_HERE_YOUR_SITEKEY'
     validators:
+      - identifier: 'Neos.Flow:NotEmpty'
       - identifier: 'Gerdemann.ReCAPTCHA:ReCAPTCHA'
         options:
           secret: 'ENTER_HERE_YOUR_SHARED_SECRET'


### PR DESCRIPTION
Without separate validator for non-empty values, the recaptcha could by-passed by sending without JS or directly with cUrl...

The  `Gerdemann.ReCAPTCHA:ReCAPTCHA` validator doesn't get triggered for empty values.

Alternativly we could change the behavior of the validator itself (`protected $acceptsEmptyValues = false;`).